### PR TITLE
Update build instructions for Webpack + add example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ module.exports = {
             os: require.resolve('os-browserify/browser'),
             stream: require.resolve('stream-browserify'),
             constants: require.resolve('constants-browserify'),
+            assert: require.resolve("assert/"), // Note the trailing slash
             buffer: require.resolve('buffer/'),  // Note the trailing slash
             process: 'process/browser',
             fs: false

--- a/README.md
+++ b/README.md
@@ -136,8 +136,7 @@ module.exports = {
 First install all dependencies:
 
 ```
-npm install webpack webpack-cli hyperswarm-web crypto-browserify path-browserify os-browserify/browser stream-browserify constants-browserify buffer process/browser
-```
+npm install webpack webpack-cli hyperswarm-web crypto-browserify path-browserify os-browserify stream-browserify constants-browserify buffer process```
 
 Then create the bundle:
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ module.exports = {
 First install all dependencies:
 
 ```
-npm install webpack webpack-cli hyperswarm-web crypto-browserify path-browserify os-browserify stream-browserify constants-browserify buffer process```
+npm install webpack webpack-cli hyperswarm-web crypto-browserify path-browserify os-browserify stream-browserify constants-browserify buffer process assert```
 
 Then create the bundle:
 

--- a/README.md
+++ b/README.md
@@ -88,29 +88,71 @@ Once you `npm run build` then you can use the generated `bundle.js` in your proj
 
 ## Compile with Webpack (webpack.config.js)
 
-To bundle with webpack, you'll need to alias some dependencies.
+These instructions are for Webpack 5.
+
+Webpack 5 no longer polyfills Node.js core modules automatically,
+so you need to polyfill quite a few of them to get it working in the browser.
+I managed to get it working with [the following config file](./webpack.config.js).
+This config file contains a few comments to better explain what happens.
+If you just want to get it working quickly,
+simply put this comment-less version in your `.webpack.config.js `:
 
 ```js
 const path = require('path')
+var webpack = require('webpack');
 
 module.exports = {
-  entry: './index.js',
-  target: 'web',
-  resolve: {
-    alias: {
-      fs: 'graceful-fs',
-      hyperswarm: 'hyperswarm-web',
-      util: './node_modules/util/util.js'
-    }
-  },
-  output: {
-    filename: 'bundle.js',
-    path: path.resolve(__dirname, 'dist')
-  }
+    'mode': 'development',
+    entry: './index.js',
+    target: 'web',
+    resolve: {
+        alias: {
+            hyperswarm: 'hyperswarm-web',
+        },
+        fallback: {
+            crypto: require.resolve("crypto-browserify"),
+            path: require.resolve("path-browserify"),
+            os: require.resolve('os-browserify/browser'),
+            stream: require.resolve('stream-browserify'),
+            constants: require.resolve('constants-browserify'),
+            buffer: require.resolve('buffer/'),  // Note the trailing slash
+            process: 'process/browser',
+            fs: false
+        },
+    },
+    plugins: [
+        new webpack.ProvidePlugin({
+            Buffer: ['buffer', 'Buffer'],
+            process: 'process/browser',
+        }),
+    ],
+    output: {
+        filename: 'bundle.js',
+        path: path.resolve(__dirname, 'dist')
+    },
 }
 ```
 
+First install all dependencies:
+
+```
+npm install webpack webpack-cli hyperswarm-web crypto-browserify path-browserify os-browserify/browser stream-browserify constants-browserify buffer process/browser
+```
+
+Then create the bundle:
+
+```
+webpack
+```
+
 Then you can include `./dist/bundle.js` in your HTML page.
+
+Note that you might need to add additional aliases or fallbacks
+if they are used within your code.
+See [webpack docs](https://webpack.js.org/configuration/resolve/#resolvefallback)
+for the full list
+of core Node.js modules which require a polyfill when used.
+
 
 ## API/Examples
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,10 +3,7 @@ This is an example config file to bundle your hyper-sdk project with webpack 5.
 
 Instructions:
 
-install webpack and webpack-cli:
-npm install webpack webpack-cli
-
-Install all dependencies used as alias or fallback:
+Install all dependencies used as alias or fallback, and webpack and webpack-cli themselves:
 npm install webpack webpack-cli hyperswarm-web crypto-browserify path-browserify os-browserify/browser stream-browserify constants-browserify buffer process/browser
 
 Run webpack:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ This is an example config file to bundle your hyper-sdk project with webpack 5.
 Instructions:
 
 Install all dependencies used as alias or fallback, and webpack and webpack-cli themselves:
-npm install webpack webpack-cli hyperswarm-web crypto-browserify path-browserify os-browserify/browser stream-browserify constants-browserify buffer process/browser
+npm install webpack webpack-cli hyperswarm-web crypto-browserify path-browserify os-browserify stream-browserify constants-browserify buffer process assert
 
 Run webpack:
 webpack
@@ -46,7 +46,7 @@ module.exports = {
             os: require.resolve('os-browserify/browser'),
             stream: require.resolve('stream-browserify'),
             constants: require.resolve('constants-browserify'),
-
+            assert: require.resolve("assert/"), // Note the trailing slash
             /*
                 The ones who follow cause errors which are only detected at runtime
                 when they are not added

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,106 @@
+/*
+This is an example config file to bundle your hyper-sdk project with webpack 5.
+
+Instructions:
+
+install webpack and webpack-cli:
+npm install webpack webpack-cli
+
+Install all dependencies used as alias or fallback:
+npm install webpack webpack-cli hyperswarm-web crypto-browserify path-browserify os-browserify/browser stream-browserify constants-browserify buffer process/browser
+
+Run webpack:
+webpack
+
+=> The bundle is created at dist/bundle.js
+
+Note that you might need to add additional aliases or fallbacks if they are used within your code. 
+See https://webpack.js.org/configuration/resolve/#resolvefallback for the full list
+of core Node.js modules which require a polyfill when used.
+
+Note: for usage within a quasar project, see below
+*/
+
+
+
+const path = require('path')
+var webpack = require('webpack');
+
+module.exports = {
+    'mode': 'development',
+    entry: './index.js',
+    target: 'web',
+    resolve: {
+        alias: {
+            hyperswarm: 'hyperswarm-web',
+            /*
+                When using graceful-fs, there is an odd runtime issue because of types at a 
+                line of Object.setProtoTypeOf
+                See: https://github.com/isaacs/node-graceful-fs/issues/222
+                It Can be resolved by manually removing that line from the bundle,
+                which is a very clumsy solution (and it removes some functionality of graceful-fs)
+                Or by not mapping fs on graceful-fs, and setting 'fs: false' in fallback, as is done now.
+            */
+            //fs: 'graceful-fs',
+        },
+        fallback: {
+            crypto: require.resolve("crypto-browserify"),
+            path: require.resolve("path-browserify"),
+            os: require.resolve('os-browserify/browser'),
+            stream: require.resolve('stream-browserify'),
+            constants: require.resolve('constants-browserify'),
+
+            /*
+                The ones who follow cause errors which are only detected at runtime
+                when they are not added
+            */
+            buffer: require.resolve('buffer/'),  // Note the trailing slash
+            process: 'process/browser', // https://stackoverflow.com/questions/65018431/webpack-5-uncaught-referenceerror-process-is-not-defined
+            fs: false
+        },
+    },
+    plugins: [
+        //SOURCE: https://viglucci.io/how-to-polyfill-buffer-with-webpack-5
+        new webpack.ProvidePlugin({
+            Buffer: ['buffer', 'Buffer'],
+            process: 'process/browser',
+        }),
+    ],
+    output: {
+        filename: 'bundle.js',
+        path: path.resolve(__dirname, 'dist')
+    },
+}
+
+
+
+/*
+For usage with quasar, simply fill build.extendWebpack in your quasar.config.js file with the equivalent info. 
+It should be something like:
+
+      extendWebpack (cfg, {isServer, isClient}) {
+        cfg.resolve.alias = {
+          ...cfg.resolve.alias, // This adds the existing aliases
+          hyperswarm: 'hyperswarm-web',
+        },
+        cfg.resolve.fallback = {
+            crypto: require.resolve("crypto-browserify"),
+            path: require.resolve("path-browserify"),
+            os: require.resolve('os-browserify/browser'),
+            stream: require.resolve('stream-browserify'),
+            constants: require.resolve('constants-browserify'),
+            // The ones who follow are only detected at runtime
+            buffer: require.resolve('buffer/'), //Note the slash. Also needs entry in 'plugins'
+            process: 'process/browser', // https://stackoverflow.com/questions/65018431/webpack-5-uncaught-referenceerror-process-is-not-defined
+            fs: false, //Note: using the alternative package yielded a very odd error
+            util: require.resolve('util'),
+            assert: require.resolve('assert'),
+        },
+        cfg.plugins.push(
+          new webpack.ProvidePlugin({
+            Buffer: ['buffer', 'Buffer'],
+            process: 'process/browser',
+          }),
+        )
+      }
+*/


### PR DESCRIPTION
This config works on a small project of mine, but I do need to add new packages to the list of fallbacks every once in a while. If used for a bigger project, you will likely have to add more fallbacks, as described. But I think this should cover the dependencies of hyper-sdk itself.  Perhaps you can try out this config on another browser-based project of yours? 

Note: webpack throws a big warning for the sodium-javascript package, which does an odd hack. I remember reading about it in some github issue, but can't pinpoint the conversation right now. The gist of it was that it is supposed to break in the browser, so I guess that's okay. But I haven't added it to the readme because I don't fully understand it and don't want to provide incorrect information.

```
WARNING in ./node_modules/sodium-javascript/randombytes.js 23:6-13
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
 @ ./node_modules/sodium-javascript/index.js 27:8-32
 @ ./node_modules/sodium-universal/index.js 1:0-41
 @ ./node_modules/hypercore-crypto/index.js 1:15-42
 @ ./node_modules/dat-sdk/index.js 9:15-42
 @ ./Hyperdrive/01_Create_a_named_drive.js 11:12-30
```

The hack in question is:
```
  if (require != null) {
    // Node.js. Bust Browserify
    crypto = require('cry' + 'pto')
    if (crypto && crypto.randomBytes) return nodeBytes
  }
```

Resolves #96 


