### PR TITLE
Use RAM.reusable() as default storage to support reopening cores

### DIFF
--- a/index.js
+++ b/index.js
@@ -371,7 +371,7 @@ export async function create ({
   if (isStringStorage && !isPathStorage) {
     storageBackend = RAA(storage)
   } else if (storage === false) {
-    storageBackend = RAM
+    storageBackend = RAM.reusable()
   }
 
   const corestore = opts.corestore || new CoreStore(storageBackend, { ...corestoreOpts })

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "hyperdrive": "^11.8.1",
     "hyperswarm": "^4.7.14",
     "random-access-application": "^2.0.0",
-    "random-access-memory": "^6.1.0",
+    "random-access-memory": "^6.2.0",
     "z32": "^1.0.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -50,6 +50,22 @@ test('Specify storage for sdk', async (t) => {
   }, { unsafeCleanup: true })
 })
 
+test('Support storage reuse by default', async (t) => {
+  const sdk = await create({ storage: false })
+  const core = await sdk.get('persist in memory')
+  const key = core.key
+
+  const data = b4a.from('beep')
+  await core.append(data)
+  await core.close()
+  t.ok(core.closed, 'initial core was closed')
+
+  const coreAgain = await sdk.get(key)
+  t.deepEqual(await coreAgain.get(0, { wait: false }), data, 'found persisted data')
+
+  await sdk.close()
+})
+
 test('Load hypercores by names and urls', async (t) => {
   const sdk = await create({ storage: false })
   const name = 'example'


### PR DESCRIPTION
Some libraries (such as `autobase`) will close their cores assuming they persist. To support this while the program is still running, `random-access-memory` supports `RAM.reusable()` which returns a reusable version of the RAM storage.