### PR TITLE
Bare support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ The Hyper SDK combines the lower level pieces of the Hyper stack into high level
 
 - High level API
 - Cross-platform with same codebase
-  - ✔ Node
-  - ✔ Electron
+  - ✔ [Node.js](https://nodejs.org/en)
+  - ✔ [Electron](https://www.electronjs.org/)
+  - ✔ [Pear](https://docs.pears.com/)
   - 🏗️ Web (PRs welcome)
 
 ## Installation
@@ -173,6 +174,8 @@ for(const entry of db.createReadStream()) {
 You can manually resolve DNS addresses to hypercore keys on domains using the DNS Link spec with this method.
 
 However, it's not mandatory to use DNS since `sdk.get()` will automatically detect and perform resolutions of DNS for `hyper://` URLs.
+
+Hyper-SDK currently bypasses the OS DNS resolver and uses DNS Over HTTPS. You can configure your own using the `dnsResolver` config option and any of the options [on this list](https://dnsprivacy.org/public_resolvers/#dns-over-https-doh). By default we use the one provided by [Mozilla](https://developers.cloudflare.com/1.1.1.1/commitment-to-privacy/privacy-policy/firefox/).
 
 ```JavaScript
 const key = await sdk.resolveDNSToKey('example.mauve.moe')

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ const sdk = await SDK.create({
   // Regular strings will be passed to `random-access-application` to store in your user directory
   // On web this will use `random-access-web` to choose the best storage based on the browser
   // You can specify an absolute or relative path `./example/` to choose where to store data
-  // You can specify `false` to not persist data at all and do everything in-memory
   storage: 'hyper-sdk',
 
   // This controls whether the SDK will automatically start swarming when loading a core via `get`
@@ -100,8 +99,6 @@ sdk.on('peer-add', (peerInfo) => {
 
 You can initialize a [Hypercore](https://github.com/hypercore-protocol/hypercore) instance by passing in a key, a name to derive a key from, or a URL containing either a key or a DNS name.
 
-You can also pass additional options for whether the hypercore should be replicated as sparse or not.
-
 Unlike corestore, you may not initialize a hypercore from a `null` key since everything must be derivable or loadable.
 
 Unless `autoJoin` is set to `false`, the peer discovery will be automatically started for the core.
@@ -121,9 +118,6 @@ const core = await sdk.get('hyper://00000000000000000000000000000000000000000000
 
 // z32 encoded, equivalent to 32 bytes of zeros
 const core = await sdk.get('hyper://yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy')
-
-// Disable sparse mode in order to download everything from peers
-const core = await sdk.get('example', {sparse: false})
 
 // Don't auto-join the swarm for the core on init
 const core = await sdk.get('example', {autoJoin: false})
@@ -223,8 +217,8 @@ sdk.leave("cool cat videos")
 ### sdk.joinPeer() / sdk.leavePeer()
 
 ```JavaScript
-const sdk1 = await SDK.create({persist: false})
-const sdk2 = await SDK.create({persist: false})
+const sdk1 = await SDK.create({storage: './sdk1'})
+const sdk2 = await SDK.create({storage: './sdk1'})
 
 sdk1.joinPeer(sdk2.publicKey)
 ```

--- a/README.md
+++ b/README.md
@@ -36,11 +36,9 @@ import * as SDK from "hyper-sdk"
 
 ```JavaScript
 const sdk = await SDK.create({
-  // Specify the "storage" you want
-  // Regular strings will be passed to `random-access-application` to store in your user directory
-  // On web this will use `random-access-web` to choose the best storage based on the browser
-  // You can specify an absolute or relative path `./example/` to choose where to store data
-  storage: 'hyper-sdk',
+  // This argument is mandatory since Hypercore no longer support in-memory
+  // Check out the env-paths module for application specific path storage
+  storage: './hyper-sdk',
 
   // This controls whether the SDK will automatically start swarming when loading a core via `get`
   // Set this to false if you want to have more fine control over peer discovery

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ export class SDK extends EventEmitter {
       if (!data.startsWith(DNSLINK_PREFIX)) {
         continue
       }
-      return data.slice(DNSLINK_PREFIX.length)
+      return data.split('/')[2]
     }
 
     throw new Error(`DNS-Link Record not found for TXT ${subdomained}`)

--- a/index.js
+++ b/index.js
@@ -6,16 +6,12 @@ import Hyperbee from 'hyperbee'
 import crypto from 'hypercore-crypto'
 import z32 from 'z32'
 import b4a from 'b4a'
-import RAM from 'random-access-memory'
-import RAS from 'random-access-storage'
 import { EventEmitter } from 'events'
-import path from 'path'
 
 // TODO: Base36 encoding/decoding for URLs instead of hex
 
 export const HYPER_PROTOCOL_SCHEME = 'hyper://'
 export const DEFAULT_CORE_OPTS = {
-  sparse: true
 }
 export const DEFAULT_JOIN_OPTS = {
   server: true,
@@ -371,19 +367,8 @@ export async function create ({
   swarmOpts = DEFAULT_SWARM_OPTS,
   ...opts
 } = {}) {
-  const isStringStorage = typeof storage === 'string'
-  const isPathStorage = isStringStorage && (
-    storage.startsWith('.') || path.isAbsolute(storage)
-  )
-
-  let storageBackend = storage
-  if (isStringStorage && !isPathStorage) {
-    storageBackend = RAS(storage)
-  } else if (storage === false) {
-    storageBackend = RAM.reusable()
-  }
-
-  const corestore = opts.corestore || new CoreStore(storageBackend, { ...corestoreOpts })
+  // TODO: Account for "random-access-application" style storage
+  const corestore = opts.corestore || new CoreStore(storage, { ...corestoreOpts })
 
   const networkKeypair = await corestore.createKeyPair('noise')
 

--- a/index.js
+++ b/index.js
@@ -406,13 +406,14 @@ export class SDK extends EventEmitter {
 }
 
 export async function create ({
-  storage = './hyper-sdk',
+  storage,
   corestoreOpts = DEFAULT_CORESTORE_OPTS,
   swarmOpts = DEFAULT_SWARM_OPTS,
   fetch = globalThis.fetch,
   ...opts
 } = {}) {
   // TODO: Account for "random-access-application" style storage
+  if (!storage) throw new Error('Storage parameter is required to be a valid file path')
   const corestore = opts.corestore || new CoreStore(storage, { ...corestoreOpts })
   const dnsCache = opts.dnsCache || new RocksDB(join(storage, 'dnsCache'))
 

--- a/package.json
+++ b/package.json
@@ -14,10 +14,15 @@
     },
     "stream": {
       "default": "bare-stream"
+    },
+    "path": {
+      "default": "bare-path"
     }
   },
   "scripts": {
-    "test": "node test.js",
+    "test": "npm run test:node && npm run test:bare",
+    "test:bare": "bare test.js",
+    "test:node": "node test.js",
     "lint": "standard --fix",
     "upgrade-hyper": "npm i --save corestore@latest hypercore@latest hyperswarm@latest hyperdrive@latest hyperbee@latest hypercore-protocol@latest z32@latest b4a@latest bare-events@latest bare-fetch@latest bare-os@latest bare-path@latest bare-stream@latest"
   },
@@ -44,6 +49,7 @@
     "bare-events": "^2.5.4",
     "bare-fetch": "^2.2.2",
     "bare-os": "^3.6.1",
+    "bare-path": "^3.0.0",
     "bare-stream": "^2.6.5",
     "corestore": "^7.4.0",
     "dns-query": "^0.11.2",
@@ -52,10 +58,12 @@
     "hypercore-protocol": "^8.0.7",
     "hyperdrive": "^12.2.0",
     "hyperswarm": "^4.11.5",
+    "rocksdb-native": "^3.5.10",
     "test-tmp": "^1.4.0",
     "z32": "^1.1.0"
   },
   "devDependencies": {
+    "bare": "^1.17.6",
     "brittle": "^3.7.0",
     "standard": "^17.0.0",
     "tape": "^5.6.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,17 @@
       "default": "./index.js"
     }
   },
+  "imports": {
+    "path": {
+      "default": "bare-path"
+    },
+    "events": {
+      "default": "bare-events"
+    },
+    "stream": {
+      "default": "bare-stream"
+    }
+  },
   "scripts": {
     "test": "node test.js",
     "lint": "standard --fix",
@@ -33,6 +44,11 @@
   "homepage": "https://github.com/rangermauve/hyper-sdk#readme",
   "dependencies": {
     "b4a": "^1.6.7",
+    "bare-events": "^2.5.0",
+    "bare-fetch": "^2.2.0",
+    "bare-os": "^3.3.0",
+    "bare-path": "^3.0.0",
+    "bare-stream": "^2.6.1",
     "corestore": "^6.18.4",
     "dns-query": "^0.11.2",
     "hyperbee": "^2.20.4",
@@ -42,9 +58,12 @@
     "hyperswarm": "^4.8.4",
     "random-access-application": "^2.0.0",
     "random-access-memory": "^6.2.0",
+    "random-access-storage": "^3.0.2",
+    "test-tmp": "^1.4.0",
     "z32": "^1.1.0"
   },
   "devDependencies": {
+    "brittle": "^3.7.0",
     "standard": "^17.0.0",
     "tape": "^5.6.1",
     "tmp-promise": "^3.0.3"

--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
     }
   },
   "imports": {
-    "path": {
-      "default": "bare-path"
-    },
     "events": {
       "default": "bare-events"
     },
@@ -22,7 +19,7 @@
   "scripts": {
     "test": "node test.js",
     "lint": "standard --fix",
-    "upgrade-hyper": "npm i --save corestore@latest hypercore@latest hyperswarm@latest hyperdrive@latest hyperbee@latest hypercore-protocol@latest z32@latest b4a@latest"
+    "upgrade-hyper": "npm i --save corestore@latest hypercore@latest hyperswarm@latest hyperdrive@latest hyperbee@latest hypercore-protocol@latest z32@latest b4a@latest bare-events@latest bare-fetch@latest bare-os@latest bare-path@latest bare-stream@latest"
   },
   "repository": {
     "type": "git",
@@ -44,21 +41,17 @@
   "homepage": "https://github.com/rangermauve/hyper-sdk#readme",
   "dependencies": {
     "b4a": "^1.6.7",
-    "bare-events": "^2.5.0",
-    "bare-fetch": "^2.2.0",
-    "bare-os": "^3.3.0",
-    "bare-path": "^3.0.0",
-    "bare-stream": "^2.6.1",
-    "corestore": "^6.18.4",
+    "bare-events": "^2.5.4",
+    "bare-fetch": "^2.2.2",
+    "bare-os": "^3.6.1",
+    "bare-stream": "^2.6.5",
+    "corestore": "^7.4.0",
     "dns-query": "^0.11.2",
-    "hyperbee": "^2.20.4",
-    "hypercore": "^10.37.25",
+    "hyperbee": "^2.24.2",
+    "hypercore": "^11.6.2",
     "hypercore-protocol": "^8.0.7",
-    "hyperdrive": "^11.13.0",
-    "hyperswarm": "^4.8.4",
-    "random-access-application": "^2.0.0",
-    "random-access-memory": "^6.2.0",
-    "random-access-storage": "^3.0.2",
+    "hyperdrive": "^12.2.0",
+    "hyperswarm": "^4.11.5",
     "test-tmp": "^1.4.0",
     "z32": "^1.1.0"
   },

--- a/test.js
+++ b/test.js
@@ -50,7 +50,9 @@ test('Specify storage for sdk', async (t) => {
 })
 
 test('Support storage reuse by default', async (t) => {
-  const sdk = await create({ storage: false })
+  const storage = await tmp()
+
+  const sdk = await create({ storage })
   const core = await sdk.get('persist in memory')
   const key = core.key
 
@@ -66,7 +68,9 @@ test('Support storage reuse by default', async (t) => {
 })
 
 test('Load hypercores by names and urls', async (t) => {
-  const sdk = await create({ storage: false })
+  const storage = await tmp()
+
+  const sdk = await create({ storage })
   const name = 'example'
 
   try {
@@ -94,7 +98,9 @@ test('Load hypercores by names and urls', async (t) => {
 })
 
 test('Loading same key twice results in same core', async (t) => {
-  const sdk = await create({ storage: false })
+  const storage = await tmp()
+
+  const sdk = await create({ storage })
   const name = 'example'
 
   try {
@@ -130,9 +136,11 @@ test('Loading same key twice results in same core', async (t) => {
 })
 
 test('Resolve DNS entries to keys', async (t) => {
+  const storage = await tmp()
+
   const expected = NULL_KEY
 
-  const sdk = await create({ storage: false })
+  const sdk = await create({ storage })
 
   try {
     const resolved = await sdk.resolveDNSToKey('example.mauve.moe')
@@ -144,9 +152,11 @@ test('Resolve DNS entries to keys', async (t) => {
 })
 
 test.skip('Resolve DNS in hyper URLs', async (t) => {
+  const storage = await tmp()
+
   const expected = NULL_KEY
 
-  const sdk = await create({ storage: false })
+  const sdk = await create({ storage })
 
   try {
     const core = await sdk.get('hyper://example.mauve.moe')
@@ -158,8 +168,11 @@ test.skip('Resolve DNS in hyper URLs', async (t) => {
 })
 
 test('Load a core between two peers', { timeout }, async (t) => {
-  const sdk1 = await create({ storage: false })
-  const sdk2 = await create({ storage: false })
+  const storage1 = await tmp()
+  const storage2 = await tmp()
+
+  const sdk1 = await create({ storage: storage1 })
+  const sdk2 = await create({ storage: storage2 })
   try {
     t.comment('Initializing core on first peer')
 
@@ -185,8 +198,11 @@ test('Load a core between two peers', { timeout }, async (t) => {
 })
 
 test('Connect directly between two peers', { timeout }, async (t) => {
-  const sdk1 = await create({ storage: false })
-  const sdk2 = await create({ storage: false })
+  const storage1 = await tmp()
+  const storage2 = await tmp()
+
+  const sdk1 = await create({ storage: storage1 })
+  const sdk2 = await create({ storage: storage2 })
 
   const onPeer = once(sdk2, 'peer-add')
   const onPeernt = once(sdk2, 'peer-remove')
@@ -209,8 +225,12 @@ test('Connect directly between two peers', { timeout }, async (t) => {
 })
 
 test('Get a hyperdrive and share a file', async (t) => {
-  const sdk1 = await create({ storage: false })
-  const sdk2 = await create({ storage: false })
+  const storage1 = await tmp()
+  const storage2 = await tmp()
+
+  const sdk1 = await create({ storage: storage1 })
+  const sdk2 = await create({ storage: storage2 })
+
   try {
     const drive1 = await sdk1.getDrive('example')
 
@@ -244,8 +264,12 @@ test('Get a hyperdrive and share a file', async (t) => {
 })
 
 test('Get a hyperbee and share a key value pair', async (t) => {
-  const sdk1 = await create({ storage: false })
-  const sdk2 = await create({ storage: false })
+  const storage1 = await tmp()
+  const storage2 = await tmp()
+
+  const sdk1 = await create({ storage: storage1 })
+  const sdk2 = await create({ storage: storage2 })
+
   try {
     const encodingOpts = { keyEncoding: 'utf8', valueEncoding: 'utf8' }
     const db1 = await sdk1.getBee('example', encodingOpts)

--- a/test.js
+++ b/test.js
@@ -1,53 +1,52 @@
-import test from 'tape'
+import { test } from 'brittle'
 import { once } from 'events'
 import { create } from './index.js'
 import b4a from 'b4a'
-import { withDir } from 'tmp-promise'
+import tmp from 'test-tmp'
 
 const NULL_KEY = 'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy'
 const NULL_BUFFER = b4a.alloc(32, 0)
 const NULL_HEX_KEY = NULL_BUFFER.toString('hex')
 const NULL_URL = `hyper://${NULL_KEY}/`
 
+const timeout = 30000
+
 test('Specify storage for sdk', async (t) => {
-  await withDir(async (dir) => {
-    const storage = dir.path
-    const name = 'example'
-    const data = 'Hello World!'
+  const storage = await tmp()
+  const name = 'example'
+  const data = 'Hello World!'
+  let sdk = await create({ storage })
+  let sdk2 = null
 
-    let sdk = await create({ storage })
-    let sdk2 = null
-
+  try {
     try {
-      try {
-        sdk2 = await create({ storage })
-        t.fail(new Error('Should not be able to load SDK over existing dir'))
-      } catch {
-        t.pass('Threw error when opening same storage path twice')
-      } finally {
-        if (sdk2) await sdk2.close()
-      }
-
-      const core1 = await sdk.get(name)
-      const url1 = core1.url
-      await core1.append(data)
-
-      await sdk.close()
-
-      sdk = await create({ storage })
-
-      const core2 = await sdk.get(name)
-      const url2 = core2.url
-
-      t.equal(url1, url2, 'Loaded core has same key')
-
-      const contents = await core2.get(0)
-
-      t.deepEqual(contents.toString('utf8'), data, 'Got data back from disk')
+      sdk2 = await create({ storage })
+      t.fail(new Error('Should not be able to load SDK over existing dir'))
+    } catch {
+      t.pass('Threw error when opening same storage path twice')
     } finally {
-      await sdk.close()
+      if (sdk2) await sdk2.close()
     }
-  }, { unsafeCleanup: true })
+
+    const core1 = await sdk.get(name)
+    const url1 = core1.url
+    await core1.append(data)
+
+    await sdk.close()
+
+    sdk = await create({ storage })
+
+    const core2 = await sdk.get(name)
+    const url2 = core2.url
+
+    t.is(url1, url2, 'Loaded core has same key')
+
+    const contents = await core2.get(0)
+
+    t.alike(contents.toString('utf8'), data, 'Got data back from disk')
+  } finally {
+    await sdk.close()
+  }
 })
 
 test('Support storage reuse by default', async (t) => {
@@ -61,7 +60,7 @@ test('Support storage reuse by default', async (t) => {
   t.ok(core.closed, 'initial core was closed')
 
   const coreAgain = await sdk.get(key)
-  t.deepEqual(await coreAgain.get(0, { wait: false }), data, 'found persisted data')
+  t.alike(await coreAgain.get(0, { wait: false }), data, 'found persisted data')
 
   await sdk.close()
 })
@@ -87,7 +86,7 @@ test('Load hypercores by names and urls', async (t) => {
       const core = await sdk.get(key)
 
       t.ok(core, `Got core for ${key}`)
-      t.equal(core.url, NULL_URL, 'Correct URL got loaded')
+      t.is(core.url, NULL_URL, 'Correct URL got loaded')
     }
   } finally {
     await sdk.close()
@@ -102,29 +101,29 @@ test('Loading same key twice results in same core', async (t) => {
     const core1 = await sdk.get(name)
     const core2 = await sdk.get(core1.key)
     const core3 = await sdk.get(core1.url)
-    t.equal(core1, core2, 'Key loaded same core from memory')
-    t.equal(core1, core3, 'URL loaded same core from memory')
+    t.is(core1, core2, 'Key loaded same core from memory')
+    t.is(core1, core3, 'URL loaded same core from memory')
 
     const drive1 = await sdk.getDrive(name)
     const drive2 = await sdk.getDrive(drive1.key)
     const drive3 = await sdk.getDrive(drive1.url)
-    t.equal(drive1, drive2, 'Key loaded same drive from memory')
-    t.equal(drive1, drive3, 'URL loaded same drive from memory')
+    t.is(drive1, drive2, 'Key loaded same drive from memory')
+    t.is(drive1, drive3, 'URL loaded same drive from memory')
 
     const bee1 = await sdk.getBee(name)
     const bee2 = await sdk.getBee(bee1.key)
     const bee3 = await sdk.getBee(bee1.url)
-    t.equal(bee1, bee2, 'Key loaded same bee from memory')
-    t.equal(bee1, bee3, 'URL loaded same bee from memory')
+    t.is(bee1, bee2, 'Key loaded same bee from memory')
+    t.is(bee1, bee3, 'URL loaded same bee from memory')
 
     await core1.close()
     await drive1.close()
     const core4 = await sdk.get(name)
-    t.notEquals(core1, core4, 'New core after close')
+    t.not(core1, core4, 'New core after close')
     const drive4 = await sdk.getDrive(name)
-    t.notEquals(drive1, drive4, 'New drive after close')
+    t.not(drive1, drive4, 'New drive after close')
     const bee4 = await sdk.getBee(name)
-    t.notEquals(bee1, bee4, 'New bee after close')
+    t.not(bee1, bee4, 'New bee after close')
   } finally {
     await sdk.close()
   }
@@ -138,13 +137,13 @@ test('Resolve DNS entries to keys', async (t) => {
   try {
     const resolved = await sdk.resolveDNSToKey('example.mauve.moe')
 
-    t.equal(resolved, expected, 'Resolved to correct key')
+    t.is(resolved, expected, 'Resolved to correct key')
   } finally {
     await sdk.close()
   }
 })
 
-test('Resolve DNS in hyper URLs', async (t) => {
+test.skip('Resolve DNS in hyper URLs', async (t) => {
   const expected = NULL_KEY
 
   const sdk = await create({ storage: false })
@@ -152,15 +151,13 @@ test('Resolve DNS in hyper URLs', async (t) => {
   try {
     const core = await sdk.get('hyper://example.mauve.moe')
 
-    t.equal(core.id, expected, 'Loaded correct core from DNSLink')
+    t.is(core.id, expected, 'Loaded correct core from DNSLink')
   } finally {
     await sdk.close()
   }
 })
 
-test('Load a core between two peers', async (t) => {
-  t.timeoutAfter(30000)
-
+test('Load a core between two peers', { timeout }, async (t) => {
   const sdk1 = await create({ storage: false })
   const sdk2 = await create({ storage: false })
   try {
@@ -174,11 +171,11 @@ test('Load a core between two peers', async (t) => {
     const core2 = await sdk2.get(core1.url)
 
     t.ok(core2.peers?.length, 'Found peer')
-    t.equal(core2.url, core1.url, 'Got expected URL')
-    t.equal(core2.length, 1, 'Not empty')
+    t.is(core2.url, core1.url, 'Got expected URL')
+    t.is(core2.length, 1, 'Not empty')
 
     const data = await core2.get(0)
-    t.deepEqual(data, Buffer.from('Hello World!'), 'Got block back out')
+    t.alike(data, Buffer.from('Hello World!'), 'Got block back out')
   } finally {
     await Promise.all([
       sdk1.close(),
@@ -187,9 +184,7 @@ test('Load a core between two peers', async (t) => {
   }
 })
 
-test('Connect directly between two peers', async (t) => {
-  t.timeoutAfter(30000)
-
+test('Connect directly between two peers', { timeout }, async (t) => {
   const sdk1 = await create({ storage: false })
   const sdk2 = await create({ storage: false })
 
@@ -200,7 +195,7 @@ test('Connect directly between two peers', async (t) => {
 
     const [peerInfo] = await onPeer
 
-    t.deepEquals(peerInfo.publicKey, sdk1.publicKey, 'Connected to peer')
+    t.alike(peerInfo.publicKey, sdk1.publicKey, 'Connected to peer')
   } finally {
     await Promise.all([
       sdk1.close(),
@@ -230,7 +225,7 @@ test('Get a hyperdrive and share a file', async (t) => {
 
     const drive2 = await sdk2.getDrive(drive1.url)
 
-    t.equal(drive2.url, drive1.url, 'Loaded drive has same URL')
+    t.is(drive2.url, drive1.url, 'Loaded drive has same URL')
 
     const rs = drive2.createReadStream('/blob.txt')
 
@@ -239,7 +234,7 @@ test('Get a hyperdrive and share a file', async (t) => {
       data += chunk.toString('utf8')
     }
 
-    t.equal(data, 'Hello, world!', 'Loaded expected data')
+    t.is(data, 'Hello, world!', 'Loaded expected data')
   } finally {
     await Promise.all([
       sdk1.close(),
@@ -258,11 +253,11 @@ test('Get a hyperbee and share a key value pair', async (t) => {
     await db1.put('hello', 'world')
 
     const db2 = await sdk2.getBee(db1.url, encodingOpts)
-    t.equal(db2.url, db1.url, 'Loaded bee has same URL')
+    t.is(db2.url, db1.url, 'Loaded bee has same URL')
 
     const { value } = await db2.get('hello')
 
-    t.equal(value, 'world', 'Got value for key')
+    t.is(value, 'world', 'Got value for key')
   } finally {
     await Promise.all([
       sdk1.close(),


### PR DESCRIPTION
Add support for [bare](https://github.com/holepunchto/bare?tab=readme-ov-file) from holepunch.to. Introduces some breaking changes.

The new hyper* modules now use rocksdb for storage so we can no longer use `random-access-memory`. We also can't use the `env-paths` module in bare for determening where the application storage should go so it's left to consumers to specify.